### PR TITLE
Chapter 05: Fixed state space initialization

### DIFF
--- a/Chapter05/Solving RL.ipynb
+++ b/Chapter05/Solving RL.ipynb
@@ -525,7 +525,7 @@
    "source": [
     "def generalized_policy_iteration(env, max_iter=2, eps=0.1, gamma=1):\n",
     "    np.random.seed(1)\n",
-    "    states =  env.observation_space\n",
+    "    states =  env.state_space\n",
     "    actions = env.action_space\n",
     "    policy = {s: {np.random.choice(actions): 1}\n",
     "             for s in states}\n",


### PR DESCRIPTION
The function `generalized_policy_iteration()` fails due to the fact its `states` variable is initialized with:
```python
    states =  env.observation_space # Which is None
```
It should be initialized with
```python
    states =  env.state_space # Same as the other cases
```
